### PR TITLE
Displaying article's title+subtitle block in more standardized way #29

### DIFF
--- a/HealthSciencesThemePlugin.inc.php
+++ b/HealthSciencesThemePlugin.inc.php
@@ -93,6 +93,9 @@ class HealthSciencesThemePlugin extends ThemePlugin {
 
 		// Check if CSS embedded to the HTML galley
 		HookRegistry::register('TemplateManager::display', array($this, 'hasEmbeddedCSS'));
+
+		// Check if article's title contains special punctuational symbols in order to subtitle's semicolon being fit
+		HookRegistry::register('TemplateManager::display', array($this, 'hasCharsInArticleTitle'));
 	}
 
 	/**
@@ -187,5 +190,27 @@ class HealthSciencesThemePlugin extends ThemePlugin {
 			'boolEmbeddedCss' => $boolEmbeddedCss,
 			'themePath' => $request->getBaseUrl() . "/" . $this->getPluginPath(),
 		));
+	}
+
+
+	// Check whether article's title has a punctuational symbol at the end
+
+	public function hasCharsInArticleTitle ($hookName, $args) {
+		$templateMgr = $args[0];
+		$template = $args[1];
+
+		// Retun false if not an article page
+		if ($template != 'frontend/pages/article.tpl') return false;
+
+		$articleArrays = $templateMgr->get_template_vars('article');
+
+		$hasPunctuation = false;
+
+		$title = $articleArrays->getLocalizedTitle();
+		if (preg_match('/\p{P}$/', trim($title))) {
+			$hasPunctuation = true;
+		}
+
+		$templateMgr->assign('hasPunctuation', $hasPunctuation);
 	}
 }

--- a/styles/objects/article-details.less
+++ b/styles/objects/article-details.less
@@ -18,9 +18,7 @@
 	font-size: 2rem;
 
 	.article-details-subtitle {
-		display: block;
-		margin-top: 0.5em;
-		font-size: @page-header-size - @page-header-size/10;
+		font-size: inherit;
 	}
 }
 

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -36,15 +36,15 @@
 		<div class="article-details-issue-identifier">
 			<a href="{url page="issue" op="view" path=$issue->getBestIssueId()}">{$issue->getIssueSeries()}</a>
 		</div>
-		<h1>
-			{$article->getLocalizedTitle()|escape}
+			<h1>
+				{$article->getLocalizedTitle()|escape}{strip}
+				{/strip}{if $article->getLocalizedSubtitle()}{if !$hasPunctuation}:{/if}
 
-			{if $article->getLocalizedSubtitle()}
-				<span class="article-details-subtitle">
-					{$article->getLocalizedSubtitle()|escape}
-				</span>
-			{/if}
-		</h1>
+					<span class="article-details-subtitle">
+						{$article->getLocalizedSubtitle()|escape}
+					</span>
+				{/if}
+			</h1>
 
 		{if $section}
 			<div class="article-details-issue-section">{$section->getLocalizedTitle()|escape}</div>


### PR DESCRIPTION
The standard format in most scientific journals is to separate article's title and subtitle only with a semicolon in one line.   