### PR TITLE
pkp/pkp-lib#3949 Use Smarty continue/break constructs

### DIFF
--- a/templates/frontend/components/navigationMenu.tpl
+++ b/templates/frontend/components/navigationMenu.tpl
@@ -17,7 +17,7 @@
 	<ul id="{$id|escape}" class="{$ulClass|escape}">
 		{foreach key=field item=navigationMenuItemAssignment from=$navigationMenu->menuTree}
 			{if !$navigationMenuItemAssignment->navigationMenuItem->getIsDisplayed()}
-				{php}continue;{/php}
+				{continue}
 			{/if}
 			{assign var="hasChildren" value=false}
 			{if !empty($navigationMenuItemAssignment->children)}

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -52,7 +52,7 @@
 			{* DOI only for large screens *}
 			{foreach from=$pubIdPlugins item=pubIdPlugin}
 				{if $pubIdPlugin->getPubIdType() != 'doi'}
-					{php}continue;{/php}
+					{continue}
 				{/if}
 				{assign var=pubId value=$article->getStoredPubId($pubIdPlugin->getPubIdType())}
 				{if $pubId}
@@ -255,7 +255,7 @@
 				{* PubIds (other than DOI; requires plugins) *}
 				{foreach from=$pubIdPlugins item=pubIdPlugin}
 					{if $pubIdPlugin->getPubIdType() == 'doi'}
-						{php}continue;{/php}
+						{continue}
 					{/if}
 					{assign var=pubId value=$article->getStoredPubId($pubIdPlugin->getPubIdType())}
 					{if $pubId}
@@ -293,7 +293,7 @@
 				{* DOI for small screens only *}
 				{foreach from=$pubIdPlugins item=pubIdPlugin}
 					{if $pubIdPlugin->getPubIdType() != 'doi'}
-						{php}continue;{/php}
+						{continue}
 					{/if}
 					{assign var=pubId value=$article->getStoredPubId($pubIdPlugin->getPubIdType())}
 					{if $pubId}

--- a/templates/frontend/objects/article_summary.tpl
+++ b/templates/frontend/objects/article_summary.tpl
@@ -57,7 +57,7 @@
 	{if $requestedPage === 'issue'}
 		{foreach from=$pubIdPlugins item=pubIdPlugin}
 			{if $pubIdPlugin->getPubIdType() != 'doi'}
-				{php}continue;{/php}
+				{continue}
 			{/if}
 			{assign var=pubId value=$article->getStoredPubId($pubIdPlugin->getPubIdType())}
 			{if $pubId}
@@ -83,7 +83,7 @@
 				{if $primaryGenreIds}
 					{assign var="file" value=$galley->getFile()}
 					{if !$galley->getRemoteUrl() && !($file && in_array($file->getGenreId(), $primaryGenreIds))}
-						{php}continue;{/php}
+						{continue}
 					{/if}
 				{/if}
 				{assign var="hasArticleAccess" value=$hasAccess}


### PR DESCRIPTION
Use Smarty3 `{break}`/`{continue}` constructs instead of `{php}break{/php}`/`{php}continue{/php}`. (`{php}` is not a safe construct and requires the user of the `SmartyBC` "backwards compatibility" class.)

OJS 3.1.x uses Smarty2, which *does not* support `{break}`/`{continue}`, so once this is merged it will not work with OJS older than 3.2.

OJS 3.2 no longer uses the `SmartyBC` class, so it will not work *until* this is merged.

Recommendation: Create a `ojs-stable-3_1_1` branch in this repo for 3.1.x compatibility. Then merge this PR into the `master` branch.