### PR TITLE
add PT Serif font to galley, as referenced in the css

### DIFF
--- a/HealthSciencesThemePlugin.inc.php
+++ b/HealthSciencesThemePlugin.inc.php
@@ -85,6 +85,7 @@ class HealthSciencesThemePlugin extends ThemePlugin {
 
 		// Styles for HTML galleys
 		$this->addStyle('htmlGalley', 'templates/plugins/generic/htmlArticleGalley/css/default.css', array('contexts' => 'htmlGalley'));
+                $this->addStyle('htmlFont', 'https://fonts.googleapis.com/css?family=PT+Serif&display=swap', array('baseUrl' => '', 'contexts' => 'htmlGalley'));
 
 		// Styles for right to left scripts
 		$locale = AppLocale::getLocale();


### PR DESCRIPTION
The css for html galleys uses a custom font (PT Serif), but the code isn't there to add it to the head section.