### PR TITLE
add copyright holder when exist

### DIFF
--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -343,6 +343,9 @@
 						{if $licenseUrl}
 							{if $ccLicenseBadge}
 								{$ccLicenseBadge}
+									{if $copyrightHolder}
+										<p>{translate key="submission.copyrightStatement" copyrightHolder=$copyrightHolder copyrightYear=$copyrightYear}</p>
+									{/if}
 							{else}
 								<a href="{$licenseUrl|escape}" class="copyright">
 									{if $copyrightHolder}


### PR DESCRIPTION
I think this was deleted by mistake. But I have to highlight something more, maybe something I missing, because in the default template the $copyright is out of any "if" and not here, and I think $copyright always exist, then is no reason put an "if" like this {if $copyright || $licenseUrl}, maybe the correct "if" is like this (for all themes, default included):  {if $copyrightHolder|| $licenseUrl} but I do not understand all about Smarty 