### PR TITLE
Only apply pkp_block styles for footer content

### DIFF
--- a/styles/components/sidebar.less
+++ b/styles/components/sidebar.less
@@ -5,8 +5,6 @@
 }
 
 .pkp_block {
-	
-	padding: 15px;
 
 	.title {
 		display: block;
@@ -21,7 +19,7 @@
 	display: inline-block;
 	background-color: white;
 	color: @black;
-	
+
 	&:focus, &:hover {
 		background-color: @dark-grey;
 		border-color: white;
@@ -43,35 +41,40 @@
 
 	.site-footer-sidebar .row {
 		justify-content: flex-start;
-	}
 
-	.pkp_block {
-		flex: 0 0 25%;
-		width: 25%;
+		.pkp_block {
+			padding: 15px;
+			flex: 0 0 25%;
+			width: 25%;
 
-			& + .pkp_block {
-				margin-top: 0;
-			}
+				& + .pkp_block {
+					margin-top: 0;
+				}
+		}
 	}
 }
 
 @media (min-width: 768px) and (max-width: 991px) {
-	.pkp_block {
-		flex: 0 0 50%;
-		width: 50%;
-		margin-bottom: 20px;
+
+	.site-footer-sidebar .row {
+		.pkp_block {
+			padding: 15px;
+			flex: 0 0 50%;
+			width: 50%;
+			margin-bottom: 20px;
+		}
 	}
 }
 
 @media (max-width: 767px) {
 	.site-footer-sidebar .row {
 		flex-direction: column;
-	}
-	
-	.pkp_block {
-		flex: 0 0 100%;
-		width: 100%;
-		margin-bottom: 20px;
+
+		.pkp_block {
+			padding: 15px;
+			flex: 0 0 100%;
+			width: 100%;
+			margin-bottom: 20px;
+		}
 	}
 }
-


### PR DESCRIPTION
Right now, `pkp_block` content such as Publication Frequency and Open Access policy that is not placed in the footer does not display into multiple columns on the same line. This layout is only intended for the footer `pkp_block`s. Specify styles so that it only applies to `pkp_block`s in the footer, and not the ones under Additional Content. 

---

Unintended look:  
<img width="918" alt="Screen Shot 2019-09-04 at 21 09 10" src="https://user-images.githubusercontent.com/6668406/64288059-05ed7d80-cf59-11e9-96cb-912b52c640f4.png">

---

Intended:  
<img width="1191" alt="Screen Shot 2019-09-04 at 21 07 57" src="https://user-images.githubusercontent.com/6668406/64288072-1140a900-cf59-11e9-8a7a-7ae6169f5135.png">

---

...This commit fixes the `pkp_block`s not in the footer like this:  
<img width="995" alt="Screen Shot 2019-09-04 at 21 09 27" src="https://user-images.githubusercontent.com/6668406/64288100-24537900-cf59-11e9-9cb1-645ce090cb14.png">
 