### PR TITLE
pkp/pkp-lib#4870 Adapt for versioning and publications

### DIFF
--- a/HealthSciencesThemePlugin.inc.php
+++ b/HealthSciencesThemePlugin.inc.php
@@ -150,7 +150,7 @@ class HealthSciencesThemePlugin extends ThemePlugin {
 	 */
 	public function loadTemplateData($hookName, $args) {
 		$templateMgr = $args[0];
-		$request = Application::getRequest();
+		$request = Application::get()->getRequest();
 		$context = $request->getContext();
 
 		if (!defined('SESSION_DISABLE_INIT')) {

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -74,10 +74,17 @@
 				{/if}
 			{/foreach}
 
-			{* Date published *}
-			{if $article->getDatePublished()}
+			{* Date published & updated *}
+			{if $publication->getData('datePublished')}
 				<div class="article-details-published">
-					{translate key="plugins.themes.healthSciences.currentIssuePublished" date=$article->getDatePublished()|date_format:$dateFormatLong}
+					{translate key="submissions.published"}
+					{* If this is the original version *}
+					{if $firstPublication->getID() === $publication->getId()}
+						{$firstPublication->getData('datePublished')|date_format:$dateFormatShort}
+					{* If this is an updated version *}
+					{else}
+						{translate key="submission.updatedOn" datePublished=$firstPublication->getData('datePublished')|date_format:$dateFormatShort dateUpdated=$publication->getData('datePublished')|date_format:$dateFormatShort}
+					{/if}
 				</div>
 			{/if}
 

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -53,7 +53,7 @@
 			</div>
 
 			<h1 class="article-details-fulltitle">
-				{$article->getLocalizedFullTitle()|escape}
+				{$publication->getLocalizedFullTitle()|escape}
 			</h1>
 
 			{if $section}
@@ -88,9 +88,9 @@
 				</div>
 			{/if}
 
-			{if $article->getAuthors()}
+			{if $publication->getData('authors')}
 				<ul class="authors-string">
-					{foreach from=$article->getAuthors() item=authorString key=authorStringKey}
+					{foreach from=$publication->getData('authors') item=authorString key=authorStringKey}
 						{strip}
 							<li>
 								{if $authorString->getLocalizedAffiliation() or $authorString->getLocalizedBiography()}
@@ -111,10 +111,10 @@
 				</ul>
 
 				{* Authors *}
-				{assign var="authorCount" value=$article->getAuthors()|@count}
+				{assign var="authorCount" value=$publication->getData('authors')|@count}
 				{assign var="authorBioIndex" value=0}
 				<div class="article-details-authors">
-					{foreach from=$article->getAuthors() item=author key=authorKey}
+					{foreach from=$publication->getData('authors') item=author key=authorKey}
 						<div class="article-details-author hideAuthor" id="author-{$authorKey+1}">
 							<div class="article-details-author-name small-screen">
 								{$author->getFullName()|escape}
@@ -175,13 +175,22 @@
 			<div class="article-details-sidebar" id="articleDetails">
 
 				{* Article/Issue cover image *}
-				{if $article->getLocalizedCoverImage() || $issue->getLocalizedCoverImage()}
+				{if $publication->getLocalizedData('coverImage') || ($issue && $issue->getLocalizedCoverImage())}
 					<div class="article-details-block article-details-cover">
-						{if $article->getLocalizedCoverImage()}
-							<img class="img-fluid" src="{$article->getLocalizedCoverImageUrl()|escape}"{if $article->getLocalizedCoverImageAltText()} alt="{$article->getLocalizedCoverImageAltText()|escape}"{/if}>
+						{if $publication->getLocalizedData('coverImage')}
+							{assign var="coverImage" value=$publication->getLocalizedData('coverImage')}
+							<img
+								class="img-fluid"
+								src="{$publication->getLocalizedCoverImageUrl($article->getData('contextId'))|escape}"
+								alt="{$coverImage.altText|escape|default:''}"
+							>
 						{else}
 							<a href="{url page="issue" op="view" path=$issue->getBestIssueId()}">
-								<img class="img-fluid" src="{$issue->getLocalizedCoverImageUrl()|escape}"{if $issue->getLocalizedCoverImageAltText()} alt="{$issue->getLocalizedCoverImageAltText()|escape}"{/if}>
+								<img
+									class="img-fluid"
+									src="{$issue->getLocalizedCoverImageUrl()|escape}"
+									alt="{$issue->getLocalizedCoverImageAltText()|escape|default:''}"
+								>
 							</a>
 						{/if}
 					</div>
@@ -329,10 +338,10 @@
 			<div class="article-details-main" id="articleMain">
 
 				{* Abstract *}
-				{if $article->getLocalizedAbstract()}
+				{if $publication->getLocalizedData('abstract')}
 					<div class="article-details-block article-details-abstract">
 						<h2 class="article-details-heading">{translate key="article.abstract"}</h2>
-						{$article->getLocalizedAbstract()|strip_unsafe_html}
+						{$publication->getLocalizedData('abstract')|strip_unsafe_html}
 					</div>
 				{/if}
 
@@ -372,7 +381,7 @@
 								{foreach from=$parsedCitations item=parsedCitation}
 									<p>{$parsedCitation->getCitationWithLinks()|strip_unsafe_html}</p>
 								{/foreach}
-							{elseif $article->getCitations()}
+							{else}
 								{$publication->getData('citationsRaw')|nl2br}
 							{/if}
 						</div>

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -194,6 +194,30 @@
 					{/foreach}
 				{/capture}
 
+        {* Display other versions *}
+        {if $publication->getData('datePublished')}
+          {if count($article->getPublishedPublications()) > 1}
+    				<div class="article-details-block">
+    					<h2 class="article-details-heading">
+    						{translate key="submission.versions"}
+    					</h2>
+    					<ul>
+    					{foreach from=array_reverse($article->getPublishedPublications()) item=iPublication}
+    						{capture assign="name"}{translate key="submission.versionIdentity" datePublished=$iPublication->getData('datePublished')|date_format:$dateFormatShort version=$iPublication->getData('version')}{/capture}
+    						<li>
+    							{if $iPublication->getId() === $publication->getId()}
+    								{$name}
+    							{elseif $iPublication->getId() === $currentPublication->getId()}
+    								<a href="{url page="article" op="view" path=$article->getBestId()}">{$name}</a>
+    							{else}
+    								<a href="{url page="article" op="view" path=$article->getBestId()|to_array:"version":$iPublication->getId()}">{$name}</a>
+    							{/if}
+    						</li>
+    					{/foreach}
+    					</ul>
+    				</div>
+          {/if}
+        {/if}
 
 				{* Article Galleys (sidebar -- only visible on small devices) *}
 				{if $primaryGalleys}

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -32,6 +32,17 @@
 <div class="article-details">
 	<div class="page-header row">
 		<div class="col-lg article-meta-mobile">
+			{* Notification that this is an old version *}
+			{if $currentPublication->getId() !== $publication->getId()}
+			<div class="alert alert-primary" role="alert">
+				{capture assign="latestVersionUrl"}{url page="article" op="view" path=$article->getBestId()}{/capture}
+				{translate key="submission.outdatedVersion"
+					datePublished=$publication->getData('datePublished')|date_format:$dateFormatShort
+					urlRecentVersion=$latestVersionUrl|escape
+				}
+			</div>
+			{/if}
+
 			{* Title and issue details *}
 			<div class="article-details-issue-section small-screen">
 				<a href="{url page="issue" op="view" path=$issue->getBestIssueId()}">{$issue->getIssueSeries()|escape}</a>{if $section}, <span>{$section->getLocalizedTitle()|escape}</span>{/if}

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -362,18 +362,18 @@
 				{/if}
 
 				{* References *}
-				{if $parsedCitations->getCount() || $article->getCitations()}
+				{if $parsedCitations || $publication->getData('citationsRaw')}
 					<div class="article-details-block article-details-references">
 						<h2 class="article-details-heading">
 							{translate key="submission.citations"}
 						</h2>
 						<div class="article-details-references-value">
-							{if $parsedCitations->getCount()}
-								{iterate from=parsedCitations item=parsedCitation}
+							{if $parsedCitations}
+								{foreach from=$parsedCitations item=parsedCitation}
 									<p>{$parsedCitation->getCitationWithLinks()|strip_unsafe_html}</p>
-								{/iterate}
+								{/foreach}
 							{elseif $article->getCitations()}
-								{$article->getCitations()|nl2br}
+								{$publication->getData('citationsRaw')|nl2br}
 							{/if}
 						</div>
 					</div>

--- a/templates/frontend/objects/article_summary.tpl
+++ b/templates/frontend/objects/article_summary.tpl
@@ -14,7 +14,7 @@
  * @uses $hideGalleys bool Hide the article galleys for this article?
  * @uses $primaryGenreIds array List of file genre ids for primary file types
  *}
-{assign var=articlePath value=$article->getBestArticleId()}
+{assign var=articlePath value=$article->getBestId()}
 
 {if (!$section.hideAuthor && $article->getHideAuthor() == $smarty.const.AUTHOR_TOC_DEFAULT) || $article->getHideAuthor() == $smarty.const.AUTHOR_TOC_SHOW}
 	{assign var="showAuthor" value=true}
@@ -87,7 +87,7 @@
 					{/if}
 				{/if}
 				{assign var="hasArticleAccess" value=$hasAccess}
-				{if ($article->getAccessStatus() == $smarty.const.ARTICLE_ACCESS_OPEN)}
+				{if $currentContext->getSetting('publishingMode') == $smarty.const.PUBLISHING_MODE_OPEN || $article->getCurrentPublication()->getData('accessStatus') == $smarty.const.ARTICLE_ACCESS_OPEN}
 					{assign var="hasArticleAccess" value=1}
 				{/if}
 				{include file="frontend/objects/galley_link.tpl" parent=$article hasAccess=$hasArticleAccess}

--- a/templates/frontend/objects/galley_link.tpl
+++ b/templates/frontend/objects/galley_link.tpl
@@ -37,7 +37,7 @@
 	{assign var="parentId" value=$parent->getBestIssueId()}
 {else}
 	{assign var="page" value="article"}
-	{assign var="parentId" value=$parent->getBestArticleId()}
+	{assign var="parentId" value=$parent->getBestId()}
 {/if}
 
 {* Get user access flag *}

--- a/templates/frontend/objects/issue_toc.tpl
+++ b/templates/frontend/objects/issue_toc.tpl
@@ -12,14 +12,14 @@
  * @uses $issueSeries string Vol/No/Year string for the issue
  * @uses $issueGalleys array Galleys for the entire issue
  * @uses $hasAccess bool Can this user access galleys for this context?
- * @uses $publishedArticles array Lists of articles published in this issue
+ * @uses $publishedSubmissions array Lists of articles published in this issue
  *   sorted by section.
  * @uses $primaryGenreIds array List of file genre ids for primary file types
  * @uses $sectionHeading string Tag to use (h2, h3, etc) for section headings
  *}
 <div class="issue-toc">
 
-	{foreach name=sections from=$publishedArticles item=section}
+	{foreach name=sections from=$publishedSubmissions item=section}
 		<div class="issue-toc-section">
 			{if $section.articles}
 				{if $section.title}

--- a/templates/frontend/pages/issueInterstitial.tpl
+++ b/templates/frontend/pages/issueInterstitial.tpl
@@ -19,7 +19,7 @@
 	{assign var="parentId" value=$parent->getBestIssueId()}
 	{url op="view" path=$parentId}
 {else}
-	{assign var="parentId" value=$parent->getBestArticleId()}
+	{assign var="parentId" value=$parent->getBestId()}
 	{url page="article" op="view" path=$parentId}
 {/if}
 {/capture}

--- a/templates/frontend/pages/search.tpl
+++ b/templates/frontend/pages/search.tpl
@@ -45,7 +45,7 @@
 				{* Results pagination *}
 				{else}
 					{iterate from=results item=result}
-						{include file="frontend/objects/article_summary.tpl" article=$result.publishedArticle journal=$result.journal showDatePublished=true hideGalleys=true}
+						{include file="frontend/objects/article_summary.tpl" article=$result.publishedSubmission journal=$result.journal showDatePublished=true hideGalleys=true}
 					{/iterate}
 					<div class="pagination">
 						{page_info iterator=$results}

--- a/templates/frontend/pages/searchAuthorDetails.tpl
+++ b/templates/frontend/pages/searchAuthorDetails.tpl
@@ -24,7 +24,7 @@
 			<div class="page-content" id="authorDetails">
 				<h3 class="author-details-author text-lg-center">{$lastName|escape}, {$firstName|escape}{if $middleName} {$middleName|escape}{/if}{if $affiliation}, {$affiliation|escape}{/if}{if $country}, {$country|escape}{/if}</h3>
 				<ul class="author-details-articles">
-					{foreach from=$publishedArticles item=article}
+					{foreach from=$submissions item=article}
 						{assign var=issueId value=$article->getIssueId()}
 						{assign var=issue value=$issues[$issueId]}
 						{assign var=issueUnavailable value=$issuesUnavailable.$issueId}

--- a/templates/frontend/pages/searchAuthorDetails.tpl
+++ b/templates/frontend/pages/searchAuthorDetails.tpl
@@ -39,12 +39,12 @@
 									<span>{$section->getLocalizedTitle()|escape}</span>
 								</div>
 								<div class="author-details-block author-details-article">
-									<a href="{url journal=$journal->getPath() page="article" op="view" path=$article->getBestArticleId()}">{$article->getLocalizedTitle()|strip_unsafe_html}</a>
+									<a href="{url journal=$journal->getPath() page="article" op="view" path=$article->getBestId()}">{$article->getLocalizedTitle()|strip_unsafe_html}</a>
 								</div>
-								{if (!$issueUnavailable || $article->getAccessStatus() == $smarty.const.ARTICLE_ACCESS_OPEN)}
+								{if (!$issueUnavailable || $publication->getData('accessStatus') == $smarty.const.ARTICLE_ACCESS_OPEN}}
 									<div class="author-details-block author-details-galleys">
 										{foreach from=$article->getGalleys() item=galley name=galleyList}
-											<a href="{url journal=$journal->getPath() page="article" op="view" path=$article->getBestArticleId()|to_array:$galley->getBestGalleyId()}"
+											<a href="{url journal=$journal->getPath() page="article" op="view" path=$article->getBestId()|to_array:$galley->getBestGalleyId()}"
 											   class="btn btn-primary">{$galley->getGalleyLabel()|escape}</a>
 										{/foreach}
 									</div>

--- a/templates/plugins/generic/htmlArticleGalley/templates/display.tpl
+++ b/templates/plugins/generic/htmlArticleGalley/templates/display.tpl
@@ -17,19 +17,27 @@
 {* Header wrapper *}
 <header class="header_view">
 
-	<a href="{url page="article" op="view" path=$article->getBestArticleId()}" class="return">
+	<a href="{url page="article" op="view" path=$article->getBestId()}" class="return">
 		<span class="pkp_screen_reader">
 			{translate key="article.return"}
 		</span>
 	</a>
-
-	<a href="{url page="article" op="view" path=$article->getBestArticleId()}" class="title">
-		{$article->getLocalizedTitle()|escape}
+	{if !$isLatestPublication}
+	<div class="title" role="alert">
+		{translate key="submission.outdatedVersion"
+			datePublished=$galleyPublication->getData('datePublished')|date_format:$dateFormatLong
+			urlRecentVersion=$parentUrl
+		}
+	</div>
+	{else}
+	<a href="{url page="article" op="view" path=$article->getBestId()}" class="title">
+		{$galleyPublication->getLocalizedTitle()|escape}
 	</a>
+	{/if}
 </header>
 
 <div id="htmlContainer" class="galley_view" style="overflow:visible;-webkit-overflow-scrolling:touch">
-	<iframe id="htmlGalleyFrame" name="htmlFrame" src="{url page="article" op="download" path=$article->getBestArticleId()|to_array:$galley->getBestGalleyId() inline=true}" allowfullscreen webkitallowfullscreen></iframe>
+	<iframe id="htmlGalleyFrame" name="htmlFrame" src="{url page="article" op="download" path=$article->getBestId()|to_array:$galley->getBestGalleyId() inline=true}" allowfullscreen webkitallowfullscreen></iframe>
 </div>
 {call_hook name="Templates::Common::Footer::PageFooter"}
 </body>

--- a/templates/plugins/generic/pdfJsViewer/templates/display.tpl
+++ b/templates/plugins/generic/pdfJsViewer/templates/display.tpl
@@ -23,9 +23,19 @@
 						{translate key="article.return"}
 					{/if}
 				</span>
-				{$title}
+				{if $isLatestPublication}
+					{$title|escape}
+				{/if}
 			</a>
 		</div>
+		{if !$isLatestPublication}
+		<div class="alert alert-primary" role="alert">
+			{translate key="submission.outdatedVersion"
+				datePublished=$galleyPublication->getData('datePublished')|date_format:$dateFormatLong
+				urlRecentVersion=$parentUrl
+			}
+		</div>
+		{/if}
 		<div class="pdf-download-button">
 			<a href="{$pdfUrl}" class="btn" download>
 				<span class="label">


### PR DESCRIPTION
This PR adds support for versioning in 3.2 and adjusts for the new split between publications and submissions.  Some screenshots based on Sophy's work in #174.

## Notice when viewing old version of article.
![Selection_213](https://user-images.githubusercontent.com/2306629/74758650-884fcc80-526f-11ea-8efc-6c4dd5d41a86.png)

## Navigate between versions from article landing page.
![Selection_214](https://user-images.githubusercontent.com/2306629/74758654-8980f980-526f-11ea-8834-25ea84413fd6.png)

## Notice when viewing old PDF galley
![Selection_215](https://user-images.githubusercontent.com/2306629/74758655-8980f980-526f-11ea-80d6-219b5338acb0.png)

## Notice when viewing old HTML  galley
![Selection_216](https://user-images.githubusercontent.com/2306629/74758657-8a199000-526f-11ea-84f1-8b6a36c0b869.png)
