### PR TITLE
Update issue_toc.tpl

### DIFF
--- a/templates/frontend/objects/issue_toc.tpl
+++ b/templates/frontend/objects/issue_toc.tpl
@@ -23,7 +23,7 @@
 		<div class="issue-toc-section">
 			{if $section.articles}
 				{if $section.title}
-					<{$sectionHeading} class="issue-toc-section-title">{$section.title|escape}</{$sectionHeading}>
+					<div class="issue-toc-section-title">{$section.title|escape}</div>
 				{/if}
 				{foreach from=$section.articles item=article}
 					{include file="frontend/objects/article_summary.tpl"}


### PR DESCRIPTION
sanity around $section.title entity. 

I encountered a weird display of section name in collaboration with toc to email plugin. I think it would be beneficial for others who use health science template, too.

`An issue has been published.
< class="issue-toc-section-title">Editorial
Dorota Brzozowska, Wladyslaw Chlopicki, Villy Tsakona, Joao Pedro Rosa Ferreira, Anastasiya Fiadotava, Paavo Kerkkänen, Aziz Kholmatov, Liisi Laineste, Gabriella Maestrini, Vicky Manteli, Vittorio Marone, Marit Piirman, Ghaleb Rababah
1-18`