### PR TITLE
Fixe: Variable declaration in article summary

### DIFF
--- a/templates/frontend/objects/article_summary.tpl
+++ b/templates/frontend/objects/article_summary.tpl
@@ -40,7 +40,7 @@
 		<div class="article-summary-authors">{$article->getAuthorString()|escape}</div>
 	{elseif $submissionPages}
 		<div class="article-summary-pages text-right">
-			{submissionPages|escape}
+			{$submissionPages|escape}
 		</div>
 	{/if}
 


### PR DESCRIPTION
When I create and published the submission in [OJS 3.3.0](https://github.com/pkp/ojs/tree/stable-3_3_0), and I choose view this submission, this error is showed:

```sh
Smarty Compiler: Syntax error in template "app:app:frontendobjectsarticle_summary.tpl"  on line 43 "{submissionPages|escape}" unknown tag 'submissionPages' <-- thrown in app:frontendobjectsarticle_summary.tpl on line 43
```

Viewed this error, I noticed that the [`submissionPages` variable](https://github.com/pkp/healthSciences/blob/stable-3_3_0/templates/frontend/objects/article_summary.tpl#L43) is not declared correctly.

So I'm doing this correction PR.